### PR TITLE
feat: added option to have one nat gateway per az

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,11 +20,12 @@ module "this" {
   intra_subnet_suffix   = var.intra_subnet_suffix
 
   ## Gateway
-  enable_nat_gateway   = var.enable_nat_gateway
-  single_nat_gateway   = var.single_nat_gateway
-  create_igw           = var.create_igw
-  enable_vpn_gateway   = false
-  enable_dns_hostnames = true
+  enable_nat_gateway     = var.enable_nat_gateway
+  single_nat_gateway     = var.single_nat_gateway
+  one_nat_gateway_per_az = var.one_nat_gateway_per_az
+  create_igw             = var.create_igw
+  enable_vpn_gateway     = false
+  enable_dns_hostnames   = true
 
   ## Disable AWS default resources
   manage_default_route_table    = false

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "single_nat_gateway" {
   default     = true
 }
 
+variable "one_nat_gateway_per_az" {
+  description = "Should be true if you want to provision a single NAT Gateway per AZ across all of your private networks."
+  type        = bool
+  default     = true
+}
+
 variable "create_igw" {
   description = "Controls if an Internet Gateway is created for public subnets and the related routes that connect them."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "single_nat_gateway" {
 variable "one_nat_gateway_per_az" {
   description = "Should be true if you want to provision a single NAT Gateway per AZ across all of your private networks."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "create_igw" {


### PR DESCRIPTION
The community module `terraform-aws-modules/vpc/aws` has the option `one_nat_gateway_per_az` which allows to create a single nat gatway for each az. I added this option to the module.